### PR TITLE
[config/routes][hapi/ViewController] Added catchall route in ViewController to handle 404 requests

### DIFF
--- a/archetype/api/controllers/hapi/DefaultController.js
+++ b/archetype/api/controllers/hapi/DefaultController.js
@@ -12,5 +12,9 @@ module.exports = {
    */
   info (request, reply) {
     reply(this.api.services.DefaultService.getApplicationInfo())
+  },
+
+  catchAll (request, reply) {
+    reply('<h1>This is the wrong trail</h1>');
   }
 }

--- a/archetype/api/controllers/hapi/ViewController.js
+++ b/archetype/api/controllers/hapi/ViewController.js
@@ -2,9 +2,5 @@ module.exports = {
 
   helloWorld (request, reply) {
     reply('Hello Trails.js !');
-  },
-
-  catchAll (request, reply) {
-    reply('<h1>This is the wrong trail</h1>');
   }
 }

--- a/archetype/api/controllers/hapi/ViewController.js
+++ b/archetype/api/controllers/hapi/ViewController.js
@@ -4,7 +4,7 @@ module.exports = {
     reply('Hello Trails.js !');
   },
 
-  catchAll(request, reply) {
-  	reply('<h1>This is the wrong trail</h1>');
+  catchAll (request, reply) {
+    reply('<h1>This is the wrong trail</h1>');
   }
 }

--- a/archetype/api/controllers/hapi/ViewController.js
+++ b/archetype/api/controllers/hapi/ViewController.js
@@ -2,5 +2,9 @@ module.exports = {
 
   helloWorld (request, reply) {
     reply('Hello Trails.js !');
+  },
+
+  catchAll(request, reply) {
+  	reply('<h1>This is the wrong trail</h1>');
   }
 }

--- a/archetype/config/routes.js
+++ b/archetype/config/routes.js
@@ -29,6 +29,6 @@ module.exports = [
   {
     method: 'GET',
     path: '/{p*}',
-    handler: 'ViewController.catchAll';
+    handler: 'ViewController.catchAll'
   }
 ]

--- a/archetype/config/routes.js
+++ b/archetype/config/routes.js
@@ -29,6 +29,6 @@ module.exports = [
   {
     method: 'GET',
     path: '/{p*}',
-    handler: 'ViewController.catchAll'
+    handler: 'DefaultController.catchAll'
   }
 ]

--- a/archetype/config/routes.js
+++ b/archetype/config/routes.js
@@ -24,5 +24,11 @@ module.exports = [
     method: [ 'GET' ],
     path: '/api/v1/default/info',
     handler: 'DefaultController.info'
+  },
+
+  {
+    method: 'GET',
+    path: '/{p*}',
+    handler: 'ViewController.catchAll';
   }
 ]


### PR DESCRIPTION
Resolves #5 

1. Created catchAll route to handle 404 request.
2. Created catchAll function to handle 404 requests.


**Note:** To server up static html files in hapi, **inert** is a dependency that is required when registering routes.  If we want to do that vs **this** temporary implementation, when we map over the routes, that function and dependency needs to be applied.  