### PR TITLE
Add issue stats badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![NPM version][npm-image]][npm-url]
 [![Build status][ci-image]][ci-url]
 [![Dependency Status][daviddm-image]][daviddm-url]
+[![Issue Stats][issuestats-image]][issuestats-url]
 [![Follow @trailsjs on Twitter][twitter-image]][twitter-url]
 
 Trails is a modern, community-driven web application framework for node.js. It
@@ -122,6 +123,8 @@ docs for more info.
 [ci-url]: https://travis-ci.org/trailsjs/trails
 [daviddm-image]: http://img.shields.io/david/trailsjs/trails.svg?style=flat-square
 [daviddm-url]: https://david-dm.org/trailsjs/trails
+[issuestats-image]: http://issuestats.com/github/trailsjs/trails/badge/issue?style=flat-square
+[issuestats-url]: http://issuestats.com/github/trailsjs/trails
 [gitter-image]: http://img.shields.io/badge/+%20GITTER-JOIN%20CHAT%20%E2%86%92-1DCE73.svg?style=flat-square
 [gitter-url]: https://gitter.im/trailsjs/trails
 [twitter-image]: https://img.shields.io/twitter/follow/trailsjs.svg?style=social


### PR DESCRIPTION
Given that the main reason this project exists is because of stagnation in SailsJS, I thought it would be appropriate to boast issue-closing times.

https://github.com/vuejs/vue/ does this and it's really appealing to see sub 12hr ticket close times.