### PR TITLE
Localize eslint override

### DIFF
--- a/lib/trails.js
+++ b/lib/trails.js
@@ -1,4 +1,3 @@
-/*eslint no-console: 0 */
 'use strict'
 
 const TrailsUtil = module.exports = {
@@ -41,7 +40,7 @@ const TrailsUtil = module.exports = {
   bindEvents (app) {
     if (app.bound) {
       app.log.warn('Someone attempted to bindEvents() twice! Stacktrace below.')
-      app.log.warn(console.trace())
+      app.log.warn(console.trace())   // eslint-disable-line no-console
       return
     }
 
@@ -85,4 +84,3 @@ const TrailsUtil = module.exports = {
     app.bound = false
   }
 }
-


### PR DESCRIPTION
No need to disable the `no-console` rule on the whole file since it's used only
once in the file. This also ensures proper feedback the next time someone
attempts to violate the rule elsewhere in this file.