### PR TITLE
Included 'waterline-sqlite3' as dependency

### DIFF
--- a/archetype/package.json
+++ b/archetype/package.json
@@ -15,6 +15,7 @@
     "trails-model": "^1.0.0-beta-2",
     "trails-policy": "^1.0.1",
     "trails-service": "1.0.0-beta-2",
+    "waterline-sqlite3": "^1.0.0",
     "winston": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
 to avoid initial `npm start` issue in getting-started doc.