### PR TITLE
Use require.main to determine paths.root

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = class TrailsApp extends events.EventEmitter {
       fs.statSync(this.config.main.paths.root)
     }
     catch (e) {
-      this.config.main.paths.root = path.resolve(process.cwd())
+      // If the root is not set, use the application's entry point to determine current root
+      this.config.main.paths.root = path.resolve(path.dirname(require.main.filename))
 
       this.log.warn('The config setting main.paths.root is not found on disk')
       this.log.warn('Setting main.paths.root =', this.config.main.paths.root)


### PR DESCRIPTION
This uses `require.main` to determine where the root path should be, instead of current working directory.

This seems like a more reasonable approach, because the root path is relative to the current application's entry point, ie. *index.js* or *app.js* or *server.js* etc. instead of where in the terminal I currently am.

In practice...

**Before**:
cwd: */home*
Command: node projects/trails-app/index.js
Root is: */home*

**After**:
cwd: */home*
Command: node projects/trails-app/index.js
Root is: */home/projects/trails-app*