### PR TITLE
Fix OS X builds on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+osx_image: xcode7.3
 node_js:
 - '4'
 - stable


### PR DESCRIPTION
Builds currently fail on OS X machines because nvm is missing. Using the newest OS X image should resolve that issue.
See https://blog.travis-ci.com/2016-03-23-xcode-image-updates