### PR TITLE
Only clean up own event listeners from process

### DIFF
--- a/lib/trails.js
+++ b/lib/trails.js
@@ -68,14 +68,8 @@ const TrailsUtil = module.exports = {
    * Bind listeners to node system events
    */
   bindSystemEvents (app) {
-    process
-      .on('exit', () => {
-        app.log.verbose('Event loop is empty. Shutting down')
-      })
-      .on('uncaughtException', err => {
-        app.log.error('uncaughtException', err)
-        app.stop(err)
-      })
+    process.on('exit', app.onExit)
+    process.on('uncaughtException', app.onUncaughtException)
   },
 
   /**
@@ -84,8 +78,8 @@ const TrailsUtil = module.exports = {
   unbindEvents (app) {
     app.removeAllListeners()
 
-    process.removeAllListeners('exit')
-    process.removeAllListeners('uncaughtException')
+    process.removeListener('exit', app.onExit)
+    process.removeListener('uncaughtException', app.onUncaughtException)
 
     app.bound = false
   }

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,30 @@ describe('Trails', () => {
             return app.stop()
           })
       })
+
+      it('should remove only those event handlers from process it created', () => {
+        // Gather initial state
+        const exitListeners = process.listenerCount('exit')
+        const excListeners = process.listenerCount('uncaughtException')
+
+        return Promise.all([
+          new TrailsApp(testAppDefinition).start(),
+          new TrailsApp(testAppDefinition).start()
+        ])
+        .then(apps => {
+          // Each Trails app should have added one listener for these events
+          assert.equal(process.listenerCount('exit'), exitListeners + 2)
+          assert.equal(process.listenerCount('uncaughtException'), excListeners + 2)
+
+          // Stop only one of the apps
+          return apps[0].stop()
+        })
+        .then(() => {
+          // Only events from a single app should have been removed
+          assert.equal(process.listenerCount('exit'), exitListeners + 1)
+          assert.equal(process.listenerCount('uncaughtException'), excListeners + 1)
+        })
+      })
     })
     describe('#constructor', () => {
       let app


### PR DESCRIPTION
This patch fixes an issue where having multiple Trails apps running in a single process and gracefully shutting one of them down would remove every other app's `uncaughtException` handler. This would cause the process to simply crash the next time there is an uncaught exception.

With this patch, each app only removes its own handlers it attached to `process` on startup, so that other apps remain unaffected.