### PR TITLE
Install & configure Istanbul

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,10 @@
+---
+instrumentation:
+  # Include all source files so we know which files are not tested at all
+  include-all-sources: true
+
+reporting:
+  reports:
+    # Lcov output can be used by some other program, and the html report can be viewed by humans in
+    # browser - coverage/lcov-report/index.html
+    - lcov

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "server"
   ],
   "scripts": {
-    "test": "eslint . && mocha"
+    "test": "eslint . && mocha",
+    "coverage": "istanbul cover _mocha"
   },
   "repository": {
     "type": "git",
@@ -60,6 +61,7 @@
   "devDependencies": {
     "eslint": "^2.0.0-beta.2",
     "eslint-config-trails": "^1.0",
+    "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
     "trailpack": "^1.0.0-alpha-1",
     "winston": "^2.1.1"


### PR DESCRIPTION
### Blocked by #123 

> The coverage reports will not be generated without #123 being merged because Istanbul most likely relies on an `exit` event which we clear when we gracefully shutdown a Trails app.

This installs Istanbul, the famous code coverage reporter, so we can keep track of how much code we have covered by tests.

The next step after this might be to have these stats published somewhere, ie. coveralls.io . I can submit a separate PR for that after this one is merged, if you like.