### PR TITLE
Add OnceAny for listen multiples optionals

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,9 @@ module.exports = class TrailsApp extends events.EventEmitter {
       handler.apply(this, Array.prototype.slice.call(arguments, 0))
     }
 
-    events.forEach(e => this.addListener(e, cb(e)))
+    events.forEach(e => {
+      this.addListener(e, cb)
+    })
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -168,17 +168,13 @@ module.exports = class TrailsApp extends events.EventEmitter {
       return
     if (!(events instanceof Array))
       events = [events]
-    const self = this
-    const genCb = function(eventName){
-      const cb = function(){
-        self.removeListener(eventName, cb)
-        handler.apply(self, Array.prototype.slice.call(arguments, 0))
-      }
-      return cb
+
+    const cb = (e) => {
+      this.removeListener(e, cb)
+      handler.apply(this, Array.prototype.slice.call(arguments, 0))
     }
-    events.forEach(function(e){
-      self.addListener(e, genCb(e))
-    })
+
+    events.forEach(e => this.addListener(e, cb(e)))
   }
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -207,6 +207,13 @@ describe('Trails', () => {
 
         return eventPromise
       })
+      it('should invoke listener when listening for multiple possible events', () => {
+        const eventPromise = app.after([['test1', 'test2'], 'test3'])
+        app.emit('test1')
+        app.emit('test3')
+
+        return eventPromise
+      })
     })
   })
 })


### PR DESCRIPTION
#### Description
Now you can define the Listen events for the dependency management in you trailpack.js config file like this:

```javascript
initialize: {
      listen: ['trailpack:sequelize:initialized'],
      emit: [ ]
    }
```
If you have support for different functionalities or support different types of trailpacks like 2 orm, you cannot put optionals events.

With this PR you can define the listen events like this:

```javascript
initialize: {
      listen: [['trailpack:sequelize:initialized','trailpack:waterline:initialized'], 'test'],
      emit: [ ]
    }
```
If "trailpack:sequelize:initialized" **or** "trailpack:waterline:initialized" **and** "test" is launched run the code.
