### PR TITLE
Fix onceAny not correctly passing along params

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,13 +164,15 @@ module.exports = class TrailsApp extends events.EventEmitter {
    * Extend the once emiter reader for accept multi valid events
    */
   onceAny (events, handler) {
+    const self = this
+
     if (!events)
       return
-    if (!(events instanceof Array))
+    if (!Array.isArray(events))
       events = [events]
 
-    const cb = (e) => {
-      this.removeListener(e, cb)
+    function cb (e) {
+      self.removeListener(e, cb)
       handler.apply(this, Array.prototype.slice.call(arguments, 0))
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -214,6 +214,17 @@ describe('Trails', () => {
 
         return eventPromise
       })
+      it('should pass event parameters to callbacks added using `onceAny`', done => {
+        const sent = { test: true }
+
+        app.onceAny('test', received => {
+          assert.equal(received, sent)
+
+          return done()
+        })
+
+        app.emit('test', sent)
+      })
     })
   })
 })


### PR DESCRIPTION
#### Description

Arrow functions do not have their own `arguments` object, they inherit it from their function scope. This PR fixes an issue in the `onceAny` function introduced in #234.

I also amended the array check to match the one found in the `after` function, for consistency.