### PR TITLE
Remove `node_modules` from .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-node_modules
 coverage


### PR DESCRIPTION
#### Description

It is unecessary to indicate `node_modules` within `.eslintignore`, since per eslint documentation, eslint will always ignore `node_modules`

>"In addition to any patterns in a .eslintignore file, ESLint always ignores files in /node_modules/* and /bower_components/*."
> http://eslint.org/docs/user-guide/configuring