### PR TITLE
Add backers and sponsors from Open Collective

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 [![Test Coverage][coverage-image]][coverage-url]
 [![Follow @trailsjs on Twitter][twitter-image]][twitter-url]
 
+[![OpenCollective](https://opencollective.com/trails/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/trails/sponsors/badge.svg)](#sponsors)
+
+
 Trails is a modern, community-driven web application framework for node.js. It
 builds on the pedigree of [Rails](http://rubyonrails.org/) and [Grails](https://grails.org/)
 to accelerate development by adhering to a straightforward, convention-based,
@@ -98,6 +102,76 @@ See https://github.com/trailsjs/trails/wiki/FAQ
 ## Contributing
 We love contributions! Please check out our [Contributor's Guide](https://github.com/trailsjs/trails/blob/master/.github/CONTRIBUTING.md) for more
 information on how our projects are organized and how to get started.
+
+## Backers
+
+ [[Become a backer](https://opencollective.com/trails#backer)]
+
+<a href="https://opencollective.com/trails/backer/0/website" target="_blank"><img src="https://opencollective.com/trails/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/1/website" target="_blank"><img src="https://opencollective.com/trails/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/2/website" target="_blank"><img src="https://opencollective.com/trails/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/3/website" target="_blank"><img src="https://opencollective.com/trails/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/4/website" target="_blank"><img src="https://opencollective.com/trails/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/5/website" target="_blank"><img src="https://opencollective.com/trails/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/6/website" target="_blank"><img src="https://opencollective.com/trails/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/7/website" target="_blank"><img src="https://opencollective.com/trails/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/8/website" target="_blank"><img src="https://opencollective.com/trails/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/9/website" target="_blank"><img src="https://opencollective.com/trails/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/10/website" target="_blank"><img src="https://opencollective.com/trails/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/11/website" target="_blank"><img src="https://opencollective.com/trails/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/12/website" target="_blank"><img src="https://opencollective.com/trails/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/13/website" target="_blank"><img src="https://opencollective.com/trails/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/14/website" target="_blank"><img src="https://opencollective.com/trails/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/15/website" target="_blank"><img src="https://opencollective.com/trails/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/16/website" target="_blank"><img src="https://opencollective.com/trails/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/17/website" target="_blank"><img src="https://opencollective.com/trails/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/18/website" target="_blank"><img src="https://opencollective.com/trails/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/19/website" target="_blank"><img src="https://opencollective.com/trails/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/20/website" target="_blank"><img src="https://opencollective.com/trails/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/21/website" target="_blank"><img src="https://opencollective.com/trails/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/22/website" target="_blank"><img src="https://opencollective.com/trails/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/23/website" target="_blank"><img src="https://opencollective.com/trails/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/24/website" target="_blank"><img src="https://opencollective.com/trails/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/25/website" target="_blank"><img src="https://opencollective.com/trails/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/26/website" target="_blank"><img src="https://opencollective.com/trails/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/27/website" target="_blank"><img src="https://opencollective.com/trails/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/28/website" target="_blank"><img src="https://opencollective.com/trails/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/trails/backer/29/website" target="_blank"><img src="https://opencollective.com/trails/backer/29/avatar.svg"></a>
+
+## Sponsors 
+
+ [[Become a sponsor](https://opencollective.com/trails#sponsor)]
+
+<a href="https://opencollective.com/trails/sponsor/0/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/1/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/2/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/3/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/4/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/5/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/6/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/7/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/8/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/9/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/10/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/11/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/11/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/12/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/13/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/14/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/15/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/15/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/16/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/16/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/17/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/17/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/18/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/18/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/19/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/19/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/20/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/20/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/21/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/21/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/22/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/22/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/23/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/23/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/24/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/24/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/25/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/25/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/26/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/26/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/27/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/27/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/28/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/28/avatar.svg"></a>
+<a href="https://opencollective.com/trails/sponsor/29/website" target="_blank"><img src="https://opencollective.com/trails/sponsor/29/avatar.svg"></a>
 
 ## License
 [MIT](https://github.com/trailsjs/trails/blob/master/LICENSE)


### PR DESCRIPTION
Now your open collective backers and sponsors can to appear directly on your README. 
see how it'll look [here](https://github.com/apex/apex#backers)
[More info](https://github.com/opencollective/opencollective/wiki/Github-banner)
Also add badges on top.

#### Description
???

#### Issues
- resolves #???
